### PR TITLE
Add the ability to convert values in CSV filter

### DIFF
--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -70,11 +70,9 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
 
       raw = event[@source].first
       begin
-	if @converters != nil
-	    @converters = @converters.each { |s| s.to_sym }
-	end
-
-	print @converters
+        if @converters != nil
+            @converters = @converters.map { |s| s.to_sym }
+        end
 
         values = CSV.parse_line(raw, :col_sep => @separator, :quote_char => @quote_char, :converters => @converters)
 

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -72,9 +72,8 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
 
       raw = event[@source].first
       begin
-        if @converters != nil
-            @converters = @converters.map { |s| s.to_sym }
-        end
+
+        @converters.map!(&:to_sym) unless @converters.nil?
 
         values = CSV.parse_line(raw, :col_sep => @separator, :quote_char => @quote_char, :converters => @converters)
 

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -37,6 +37,10 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
   # Defaults to writing to the root of the event.
   config :target, :validate => :string
 
+  # Converters used for converting values in CSV
+  # Defaults to none (previous behavior)
+  config :converters, :validate => :array, :default => nil
+
   public
   def register
 
@@ -66,7 +70,13 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
 
       raw = event[@source].first
       begin
-        values = CSV.parse_line(raw, :col_sep => @separator, :quote_char => @quote_char)
+	if @converters != nil
+	    @converters = @converters.each { |s| s.to_sym }
+	end
+
+	print @converters
+
+        values = CSV.parse_line(raw, :col_sep => @separator, :quote_char => @quote_char, :converters => @converters)
 
         if @target.nil?
           # Default is to write to the root of the event.

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -39,6 +39,8 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
 
   # Converters used for converting values in CSV
   # Defaults to none (previous behavior)
+  # Options are all, integer, float, numeric, date, date_time
+  # Note: This is a speed impact on using this function
   config :converters, :validate => :array, :default => nil
 
   public


### PR DESCRIPTION
This PR adds the ability to use the converters option on the CSV parser - this allows end users to quickly convert values based on it's type - IE: Convert INTs etc to INTs automaticly. 


Moved from https://github.com/elasticsearch/logstash/pull/1970