### PR TITLE
Add support for type conversion when parsing csv data

### DIFF
--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -78,8 +78,8 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
           if !(@skip_empty_columns && (values[i].nil? || values[i].empty?))
             if !ignore_field?(i)
               field_name       = @columns[i] ? @columns[i] : "column#{i+1}"
-              dest[field_name] = if should_convert?(field_name)
-                                   convert(field_name, values[i])
+              dest[field_name] = if should_transform?(field_name)
+                                   transform(field_name, values[i])
                                  else
                                    values[i]
                                  end
@@ -104,11 +104,11 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
     !@columns[index] && !@autogenerate_column_names
   end
 
-  def should_convert?(field_name)
+  def should_transform?(field_name)
     !@convert[field_name].nil?
   end
 
-  def convert(field_name, value)
+  def transform(field_name, value)
     transformation = @convert[field_name].to_sym
     converters[transformation].call(value)
   end

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -56,8 +56,20 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
   #     }
   config :convert, :validate => :hash, :default => {}
 
+
+  ##
+  # List of valid conversion types used for the convert option
+  ##
+  VALID_CONVERT_TYPES = [ "integer", "float", "date", "date_time", "boolean" ].freeze
+
+
   def register
-    # Nothing to do here
+    # validate conversion types to be the valid ones.
+    @convert.each_pair do |column, type|
+      if !VALID_CONVERT_TYPES.include?(type)
+        raise LogStash::ConfigurationError, "#{type} is not a valid conversion type."
+      end
+    end
   end # def register
 
   def filter(event)

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -10,183 +10,186 @@ describe LogStash::Filters::CSV do
   let(:doc)   { "" }
   let(:event) { LogStash::Event.new("message" => doc) }
 
+  describe "registration" do
 
-  before(:each) do
-    plugin.register
-  end
+    context "when using invalid data types" do
+      let(:config) do
+        { "convert" => { "custom1" => "integer", "custom3" => "wrong_type" },
+          "columns" => ["custom1", "custom2", "custom3"] }
+      end
 
-  describe "all defaults" do
-
-    let(:doc) { "big,bird,sesame street" }
-
-    it "extract all the values" do
-      plugin.filter(event)
-      expect(event["column1"]).to eq("big")
-      expect(event["column2"]).to eq("bird")
-      expect(event["column3"]).to eq("sesame street")
-    end
-
-    it "should not mutate the source field" do
-      plugin.filter(event)
-      expect(event["message"]).to be_kind_of(String)
+      it "should register" do
+        input = LogStash::Plugin.lookup("filter", "csv").new(config)
+        expect {input.register}.to raise_error
+      end
     end
   end
 
-  describe "custom separator" do
-    let(:doc) { "big,bird;sesame street" }
+  describe "receive" do
 
-    let(:config) do
-      { "separator" => ";" }
-    end
-    it "extract all the values" do
-      plugin.filter(event)
-      expect(event["column1"]).to eq("big,bird")
-      expect(event["column2"]).to eq("sesame street")
-    end
-  end
-
-  describe "quote char" do
-    let(:doc) { "big,bird,'sesame street'" }
-
-    let(:config) do
-      { "quote_char" => "'"}
+    before(:each) do
+      plugin.register
     end
 
-    it "extract all the values" do
-      plugin.filter(event)
-      expect(event["column1"]).to eq("big")
-      expect(event["column2"]).to eq("bird")
-      expect(event["column3"]).to eq("sesame street")
-    end
+    describe "all defaults" do
 
-    context "using the default one" do
-      let(:doc) { 'big,bird,"sesame, street"' }
       let(:config) { Hash.new }
 
-      it "extract all the values" do
-        plugin.filter(event)
-        expect(event["column1"]).to eq("big")
-        expect(event["column2"]).to eq("bird")
-        expect(event["column3"]).to eq("sesame, street")
-      end
-    end
-
-    context "using a null" do
-      let(:doc) { 'big,bird,"sesame" street' }
-      let(:config) do
-        { "quote_char" => "\x00" }
-      end
+      let(:doc) { "big,bird,sesame street" }
 
       it "extract all the values" do
         plugin.filter(event)
         expect(event["column1"]).to eq("big")
         expect(event["column2"]).to eq("bird")
-        expect(event["column3"]).to eq('"sesame" street')
+        expect(event["column3"]).to eq("sesame street")
+      end
+
+      it "should not mutate the source field" do
+        plugin.filter(event)
+        expect(event["message"]).to be_kind_of(String)
       end
     end
-  end
 
-  describe "given column names" do
-    let(:doc)    { "big,bird,sesame street" }
-    let(:config) do
-      { "columns" => ["first", "last", "address" ] }
-    end
+    describe "custom separator" do
+      let(:doc) { "big,bird;sesame street" }
 
-    it "extract all the values" do
-      plugin.filter(event)
-      expect(event["first"]).to eq("big")
-      expect(event["last"]).to eq("bird")
-      expect(event["address"]).to eq("sesame street")
-    end
-
-    context "parse csv without autogeneration of names" do
-
-      let(:doc)    { "val1,val2,val3" }
       let(:config) do
-        {  "autogenerate_column_names" => false,
-           "columns" => ["custom1", "custom2"] }
+        { "separator" => ";" }
+      end
+      it "extract all the values" do
+        plugin.filter(event)
+        expect(event["column1"]).to eq("big,bird")
+        expect(event["column2"]).to eq("sesame street")
+      end
+    end
+
+    describe "quote char" do
+      let(:doc) { "big,bird,'sesame street'" }
+
+      let(:config) do
+        { "quote_char" => "'"}
       end
 
       it "extract all the values" do
         plugin.filter(event)
-        expect(event["custom1"]).to eq("val1")
-        expect(event["custom2"]).to eq("val2")
-        expect(event["column3"]).to be_falsey
+        expect(event["column1"]).to eq("big")
+        expect(event["column2"]).to eq("bird")
+        expect(event["column3"]).to eq("sesame street")
+      end
+
+      context "using the default one" do
+        let(:doc) { 'big,bird,"sesame, street"' }
+        let(:config) { Hash.new }
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["column1"]).to eq("big")
+          expect(event["column2"]).to eq("bird")
+          expect(event["column3"]).to eq("sesame, street")
+        end
+      end
+
+      context "using a null" do
+        let(:doc) { 'big,bird,"sesame" street' }
+        let(:config) do
+          { "quote_char" => "\x00" }
+        end
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["column1"]).to eq("big")
+          expect(event["column2"]).to eq("bird")
+          expect(event["column3"]).to eq('"sesame" street')
+        end
       end
     end
 
-    context "parse csv skipping empty columns" do
-
-      let(:doc)    { "val1,,val3" }
-
+    describe "given column names" do
+      let(:doc)    { "big,bird,sesame street" }
       let(:config) do
-        { "skip_empty_columns" => true,
-          "source" => "datafield",
-          "columns" => ["custom1", "custom2", "custom3"] }
+        { "columns" => ["first", "last", "address" ] }
       end
-
-      let(:event) { LogStash::Event.new("datafield" => doc) }
 
       it "extract all the values" do
         plugin.filter(event)
-        expect(event["custom1"]).to eq("val1")
-        expect(event["custom2"]).to be_falsey
-        expect(event["custom3"]).to eq("val3")
+        expect(event["first"]).to eq("big")
+        expect(event["last"]).to eq("bird")
+        expect(event["address"]).to eq("sesame street")
+      end
+
+      context "parse csv without autogeneration of names" do
+
+        let(:doc)    { "val1,val2,val3" }
+        let(:config) do
+          {  "autogenerate_column_names" => false,
+             "columns" => ["custom1", "custom2"] }
+        end
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["custom1"]).to eq("val1")
+          expect(event["custom2"]).to eq("val2")
+          expect(event["column3"]).to be_falsey
+        end
+      end
+
+      context "parse csv skipping empty columns" do
+
+        let(:doc)    { "val1,,val3" }
+
+        let(:config) do
+          { "skip_empty_columns" => true,
+            "source" => "datafield",
+            "columns" => ["custom1", "custom2", "custom3"] }
+        end
+
+        let(:event) { LogStash::Event.new("datafield" => doc) }
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["custom1"]).to eq("val1")
+          expect(event["custom2"]).to be_falsey
+          expect(event["custom3"]).to eq("val3")
+        end
+      end
+
+      context "parse csv with more data than defined" do
+        let(:doc)    { "val1,val2,val3" }
+        let(:config) do
+          { "columns" => ["custom1", "custom2"] }
+        end
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["custom1"]).to eq("val1")
+          expect(event["custom2"]).to eq("val2")
+          expect(event["column3"]).to eq("val3")
+        end
+      end
+
+      context "parse csv from a given source" do
+        let(:doc)    { "val1,val2,val3" }
+        let(:config) do
+          { "source"  => "datafield",
+            "columns" => ["custom1", "custom2", "custom3"] }
+        end
+        let(:event) { LogStash::Event.new("datafield" => doc) }
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["custom1"]).to eq("val1")
+          expect(event["custom2"]).to eq("val2")
+          expect(event["custom3"]).to eq("val3")
+        end
       end
     end
 
-    context "parse csv with more data than defined" do
-      let(:doc)    { "val1,val2,val3" }
+    describe "givin target" do
       let(:config) do
-        { "columns" => ["custom1", "custom2"] }
+        { "target" => "data" }
       end
-
-      it "extract all the values" do
-        plugin.filter(event)
-        expect(event["custom1"]).to eq("val1")
-        expect(event["custom2"]).to eq("val2")
-        expect(event["column3"]).to eq("val3")
-      end
-    end
-
-    context "parse csv from a given source" do
-      let(:doc)    { "val1,val2,val3" }
-      let(:config) do
-        { "source"  => "datafield",
-          "columns" => ["custom1", "custom2", "custom3"] }
-      end
-      let(:event) { LogStash::Event.new("datafield" => doc) }
-
-      it "extract all the values" do
-        plugin.filter(event)
-        expect(event["custom1"]).to eq("val1")
-        expect(event["custom2"]).to eq("val2")
-        expect(event["custom3"]).to eq("val3")
-      end
-    end
-  end
-
-  describe "givin target" do
-    let(:config) do
-      { "target" => "data" }
-    end
-    let(:doc)   { "big,bird,sesame street" }
-    let(:event) { LogStash::Event.new("message" => doc) }
-
-    it "extract all the values" do
-      plugin.filter(event)
-      expect(event["data"]["column1"]).to eq("big")
-      expect(event["data"]["column2"]).to eq("bird")
-      expect(event["data"]["column3"]).to eq("sesame street")
-    end
-
-    context "when having also source" do
-      let(:config) do
-        {  "source" => "datain",
-           "target" => "data" }
-      end
-      let(:event) { LogStash::Event.new("datain" => doc) }
       let(:doc)   { "big,bird,sesame street" }
+      let(:event) { LogStash::Event.new("message" => doc) }
 
       it "extract all the values" do
         plugin.filter(event)
@@ -194,38 +197,53 @@ describe LogStash::Filters::CSV do
         expect(event["data"]["column2"]).to eq("bird")
         expect(event["data"]["column3"]).to eq("sesame street")
       end
+
+      context "when having also source" do
+        let(:config) do
+          {  "source" => "datain",
+             "target" => "data" }
+        end
+        let(:event) { LogStash::Event.new("datain" => doc) }
+        let(:doc)   { "big,bird,sesame street" }
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event["data"]["column1"]).to eq("big")
+          expect(event["data"]["column2"]).to eq("bird")
+          expect(event["data"]["column3"]).to eq("sesame street")
+        end
+      end
     end
-  end
 
-  describe "using field convertion" do
-
-    let(:config) do
-      { "convert" => { "column1" => "integer", "column3" => "boolean" } }
-    end
-    let(:doc)   { "1234,bird,false" }
-    let(:event) { LogStash::Event.new("message" => doc) }
-
-    it "get converted values to the expected type" do
-      plugin.filter(event)
-      expect(event["column1"]).to eq(1234)
-      expect(event["column2"]).to eq("bird")
-      expect(event["column3"]).to eq(false)
-    end
-
-    context "when using column names" do
+    describe "using field convertion" do
 
       let(:config) do
-        { "convert" => { "custom1" => "integer", "custom3" => "boolean" },
-          "columns" => ["custom1", "custom2", "custom3"] }
+        { "convert" => { "column1" => "integer", "column3" => "boolean" } }
       end
+      let(:doc)   { "1234,bird,false" }
+      let(:event) { LogStash::Event.new("message" => doc) }
 
       it "get converted values to the expected type" do
         plugin.filter(event)
-        expect(event["custom1"]).to eq(1234)
-        expect(event["custom2"]).to eq("bird")
-        expect(event["custom3"]).to eq(false)
+        expect(event["column1"]).to eq(1234)
+        expect(event["column2"]).to eq("bird")
+        expect(event["column3"]).to eq(false)
+      end
+
+      context "when using column names" do
+
+        let(:config) do
+          { "convert" => { "custom1" => "integer", "custom3" => "boolean" },
+            "columns" => ["custom1", "custom2", "custom3"] }
+        end
+
+        it "get converted values to the expected type" do
+          plugin.filter(event)
+          expect(event["custom1"]).to eq(1234)
+          expect(event["custom2"]).to eq("bird")
+          expect(event["custom3"]).to eq(false)
+        end
       end
     end
-
   end
 end

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -180,7 +180,6 @@ describe LogStash::Filters::CSV do
       expect(event["data"]["column3"]).to eq("sesame street")
     end
 
-
     context "when having also source" do
       let(:config) do
         {  "source" => "datain",
@@ -196,5 +195,37 @@ describe LogStash::Filters::CSV do
         expect(event["data"]["column3"]).to eq("sesame street")
       end
     end
+  end
+
+  describe "using field convertion" do
+
+    let(:config) do
+      { "convert" => { "column1" => "integer", "column3" => "boolean" } }
+    end
+    let(:doc)   { "1234,bird,false" }
+    let(:event) { LogStash::Event.new("message" => doc) }
+
+    it "get converted values to the expected type" do
+      plugin.filter(event)
+      expect(event["column1"]).to eq(1234)
+      expect(event["column2"]).to eq("bird")
+      expect(event["column3"]).to eq(false)
+    end
+
+    context "when using column names" do
+
+      let(:config) do
+        { "convert" => { "custom1" => "integer", "custom3" => "boolean" },
+          "columns" => ["custom1", "custom2", "custom3"] }
+      end
+
+      it "get converted values to the expected type" do
+        plugin.filter(event)
+        expect(event["custom1"]).to eq(1234)
+        expect(event["custom2"]).to eq("bird")
+        expect(event["custom3"]).to eq(false)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Provide an option to handle type conversion when parsing csv files in a similar fashion as the one provided by the mutate filter. Like this a user can avoid having to instantiate a mutate filter when parsing csv data.