### PR TITLE
Adds check for zero byte character from the config

### DIFF
--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -96,6 +96,13 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
 
     # make sure @target is in the format [field name] if defined, i.e. surrounded by brakets
     @target = "[#{@target}]" if @target && @target !~ /^\[[^\[\]]+\]$/
+    
+    # if the zero byte character is entered in the config, set the value
+    if (@quote_char == "\\x00")
+      @quote_char = "\x00"
+    end
+    
+    @logger.debug? && @logger.debug("CSV parsing options", :col_sep => @separator, :quote_char => @quote_char)
   end
 
   def filter(event)

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -102,6 +102,20 @@ describe LogStash::Filters::CSV do
           expect(event["column3"]).to eq('"sesame" street')
         end
       end
+      
+      context "using a null as read from config" do
+        let(:doc) { 'big,bird,"sesame" street' }
+        let(:config) do
+          { "quote_char" => "\\x00" }
+        end
+
+        it "extract all the values" do
+          plugin.filter(event)
+          expect(event.get("column1")).to eq("big")
+          expect(event.get("column2")).to eq("bird")
+          expect(event.get("column3")).to eq('"sesame" street')
+        end
+      end
     end
 
     describe "given column names" do


### PR DESCRIPTION
Adds a check for the zero byte character from the config and sets the value without the encoding present when reading the value in. Currently, there is no way to set this value from the config file without having this check in place.

I would say the ideal scenario would be to switch this value top be the default rather than '"', but I would see that breaking a lot of configs.

Fixes #29 
