### PR TITLE
Added autodetect_column_names option to get column names from header

### DIFF
--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -259,5 +259,21 @@ describe LogStash::Filters::CSV do
         end
       end
     end
+
+    describe "given autodetect option" do
+      let(:header) { LogStash::Event.new("message" => "first,last,address") }
+      let(:doc)    { "big,bird,sesame street" }
+      let(:config) do
+        { "autodetect_column_names" => true }
+      end
+
+      it "extract all the values with the autodetected header" do
+        plugin.filter(header)
+        plugin.filter(event)
+        expect(event.get("first")).to eq("big")
+        expect(event.get("last")).to eq("bird")
+        expect(event.get("address")).to eq("sesame street")
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds the capability for the column names to be extracted from the first row in the input making the ordering and presence of the columns completely dynamic yet still controlled by the user. It is off by default to maintain backwards compatibility and has a unit test to prove it works.

CLA is signed.

Thanks!