### PR TITLE
Fix dropped nested fields assigned in the CSV columns pattern

### DIFF
--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -103,7 +103,7 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
     @convert_symbols = @convert.inject({}){|result, (k, v)| result[k] = v.to_sym; result}
 
     # make sure @target is in the format [field name] if defined, i.e. surrounded by brakets
-    @target = "[#{@target}]" if @target && @target !~ /^\[[^\[\]]+\]$/
+    @target = "[#{@target}]" if @target && @target !~ /^(\[[^\[\]]+\])+$/
     
     # if the zero byte character is entered in the config, set the value
     if (@quote_char == "\\x00")


### PR DESCRIPTION
So I reported this issue quite a while back in the following issue: [CSV columns breaking @metadata fields](https://github.com/logstash-plugins/logstash-filter-csv/issues/24)

It turns out that any nested fields assigned in the column matching pattern were being dropped by the CSV filter. I pinpointed the commit that broke the matching: [cleaups and correct field reference](https://github.com/logstash-plugins/logstash-filter-csv/commit/1eea4e2c2e3811d22938087f1c06283c9ed10e17)

@jordansissel identified [the line of code](https://github.com/logstash-plugins/logstash-filter-csv/commit/1eea4e2c2e3811d22938087f1c06283c9ed10e17#diff-c851d51606a2d6077587c788f2d32ec8R98) that was causing the problem:

> ``` ruby
> > @target = "hello"; @target = "[#{@target}]" if @target && @target !~ /^\[[^\[\]]+\]$/
> => "[hello]"
> > @target = "[hello]"; @target = "[#{@target}]" if @target && @target !~ /^\[[^\[\]]+\]$/
> => nil
> > @target = "[hello][world]"; @target = "[#{@target}]" if @target && @target !~ /^\[[^\[\]]+\]$/
> => "[[hello][world]]"
> ```

Looking at the regex, it seemed obvious that the regex for target in the final conditional match was only matching one instance of a string wrapped in square brackets. Nested fields contain two or more strings wrapped in square brackets. This commit resulted in the nested field name getting wrapped in an additional set of square brackets causing the name to be malformed.

By treating the regex as a capture group and requiring one or more matches, we then match nested fields specified with two or more sets of strings wrapped in square brackets and prevent them being wrapped in an additional set:

``` ruby
> @target = "foo"; @target = "[#{@target}]" if @target && @target !~ /^(\[[^\[\]]+\])+$/
=> "[foo]"
> @target = "[foo]"; @target = "[#{@target}]" if @target && @target !~ /^(\[[^\[\]]+\])+$/
=> nil
> @target = "[foo][bar]"; @target = "[#{@target}]" if @target && @target !~ /^(\[[^\[\]]+\])+$/
=> nil
> @target = "[@metadata][foo][bar]"; @target = "[#{@target}]" if @target && @target !~ /^(\[[^\[\]]+\])+$/
=> nil
```

Would be great to get this merged so I don't have to keep downgrading the plugin on every new logstash release! :sunglasses: :sunny: 
