### PR TITLE
generate Timestamp objects for correctly converted :date and :date_time fields with related specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - generate Timestamp objects for correctly converted :date and :date_time fields with related specs.
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -74,11 +74,13 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
     end,
 
     :date => lambda do |value|
-      CSV::Converters[:date].call(value)
+      result = CSV::Converters[:date].call(value)
+      result.is_a?(Date) ? LogStash::Timestamp.new(result.to_time) : result
     end,
 
     :date_time => lambda do |value|
-      CSV::Converters[:date_time].call(value)
+      result = CSV::Converters[:date_time].call(value)
+      result.is_a?(DateTime) ? LogStash::Timestamp.new(result.to_time) : result
     end,
 
     :boolean => lambda do |value|

--- a/logstash-filter-csv.gemspec
+++ b/logstash-filter-csv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-csv'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The CSV filter takes an event field containing CSV data, parses it, and stores it as individual fields (can optionally specify the names)."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #47 

The `:date` and `:date_time` converters were broken and were producing Ruby objects instead of a proper `Timestamp` to set in the `Event`.

Both converters now produce a proper `Timestamp` object and specs have been added. 

Version bumped to 3.0.3.

Also fixed a rspec warning for the `raise_error` usage.