### PR TITLE
Correctly handle [nested][field][references] for target and columns settings.

### DIFF
--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -105,7 +105,7 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
     @convert_symbols = @convert.inject({}){|result, (k, v)| result[k] = v.to_sym; result}
 
     # make sure @target is in the format [field name] if defined, i.e. surrounded by brakets
-    @target = "[#{@target}]" if @target && @target !~ /^\[[^\[\]]+\]$/
+    @target = "[#{@target}]" if @target && !@target.start_with?("[")
     
     # if the zero byte character is entered in the config, set the value
     if (@quote_char == "\\x00")
@@ -151,10 +151,14 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
   private
 
   # construct the correct Event field reference for given field_name, taking into account @target
-  # @param field_name [String] the bare field name without brakets
+  # @param field_name [String] the field name.
   # @return [String] fully qualified Event field reference also taking into account @target prefix
   def field_ref(field_name)
-    "#{@target}[#{field_name}]"
+    if field_name.start_with?("[")
+      "#{@target}#{field_name}"
+    else
+      "#{@target}[#{field_name}]"
+    end
   end
 
   def ignore_field?(index)

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -196,6 +196,25 @@ describe LogStash::Filters::CSV do
           expect(event.get("custom3")).to eq("val3")
         end
       end
+
+      context "that use [@metadata]" do
+        let(:metadata_field) { "[@metadata][one]" }
+        let(:config) do
+          {
+            "columns" => [ metadata_field, "foo" ]
+          }
+        end
+
+        let(:event) { LogStash::Event.new("message" => "hello,world") }
+
+        before do
+          plugin.filter(event)
+        end
+
+        it "should work correctly" do
+          expect(event.get(metadata_field)).to eq("hello")
+        end
+      end
     end
 
     describe "givin target" do
@@ -226,6 +245,41 @@ describe LogStash::Filters::CSV do
           expect(event.get("data")["column2"]).to eq("bird")
           expect(event.get("data")["column3"]).to eq("sesame street")
         end
+      end
+
+      context "which uses [nested][fieldref] syntax" do
+        let(:target) { "[foo][bar]" }
+        let(:config) do
+          {
+            "target" => target
+          }
+        end
+
+        let(:event) { LogStash::Event.new("message" => "hello,world") }
+
+        before do
+          plugin.filter(event)
+        end
+
+        it "should set fields correctly in the target" do
+          expect(event.get("#{target}[column1]")).to eq("hello")
+          expect(event.get("#{target}[column2]")).to eq("world")
+        end
+
+        context "with nested fieldrefs as columns" do
+          let(:config) do
+            {
+              "target" => target,
+              "columns" => [ "[test][one]", "[test][two]" ]
+            }
+          end
+
+          it "should set fields correctly in the target" do
+          expect(event.get("#{target}[test][one]")).to eq("hello")
+          expect(event.get("#{target}[test][two]")).to eq("world")
+          end
+        end
+
       end
     end
 

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -275,8 +275,8 @@ describe LogStash::Filters::CSV do
           end
 
           it "should set fields correctly in the target" do
-          expect(event.get("#{target}[test][one]")).to eq("hello")
-          expect(event.get("#{target}[test][two]")).to eq("world")
+            expect(event.get("#{target}[test][one]")).to eq("hello")
+            expect(event.get("#{target}[test][two]")).to eq("world")
           end
         end
 


### PR DESCRIPTION
This fixes two similar bugs where a field reference like `[foo][bar]`
would be wrapped incorrectly as `[[foo][bar]]` causing incorrect fields
to be set in the event.

The affected settings were `target` and `columns`.

Added tests to cover the bug fixes.

Fixes #24