### PR TITLE
Added feature to skip empty rows preventing broken event warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.8
+  - feature: Added support for tagging empty rows which users can reference to conditionally drop events
+
 ## 3.0.7
   - Update gemspec summary
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Contributors:
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
 * Suyog Rao (suyograo)
+* Abdul Haseeb Hussain (AbdulHaseebHussain)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -45,6 +45,10 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
   # Defaults to false. If set to true, columns containing no value will not get set.
   config :skip_empty_columns, :validate => :boolean, :default => false
 
+  # Define whether empty rows should be skipped.
+  # Defaults to false. If set to true, rows containing no value will not be parsed.
+  config :skip_empty_rows, :validate => :boolean, :default => false
+
   # Define a set of datatype conversions to be applied to columns.
   # Possible conversions are integer, float, date, date_time, boolean
   #
@@ -120,7 +124,13 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
 
     if (source = event.get(@source))
       begin
-        values = CSV.parse_line(source, :col_sep => @separator, :quote_char => @quote_char)
+
+        values = CSV.parse_line(source, :col_sep => @separator, :quote_char => @quote_char)        
+
+        if(@skip_empty_rows && values.nil?)
+          event.cancel
+          return
+        end
 
         if (@autodetect_column_names && @columns.empty?)
           @columns = values

--- a/lib/logstash/filters/csv.rb
+++ b/lib/logstash/filters/csv.rb
@@ -45,8 +45,9 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
   # Defaults to false. If set to true, columns containing no value will not get set.
   config :skip_empty_columns, :validate => :boolean, :default => false
 
-  # Define whether empty rows should be skipped.
-  # Defaults to false. If set to true, rows containing no value will not be parsed.
+  # Define whether empty rows could potentially be skipped.
+  # Defaults to false. If set to true, rows containing no value will be tagged with _csvskippedemptyfield.
+  # This tag can referenced by users if they wish to cancel events using an 'if' conditional statement.
   config :skip_empty_rows, :validate => :boolean, :default => false
 
   # Define a set of datatype conversions to be applied to columns.
@@ -128,7 +129,8 @@ class LogStash::Filters::CSV < LogStash::Filters::Base
         values = CSV.parse_line(source, :col_sep => @separator, :quote_char => @quote_char)        
 
         if(@skip_empty_rows && values.nil?)
-          event.cancel
+          # applies tag to empty rows, users can cancel event referencing this tag in an 'if' conditional statement
+          event.tag("_csvskippedemptyfield")
           return
         end
 

--- a/logstash-filter-csv.gemspec
+++ b/logstash-filter-csv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-csv'
-  s.version         = '3.0.7'
+  s.version         = '3.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses comma-separated value data into individual fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -50,6 +50,19 @@ describe LogStash::Filters::CSV do
       end
     end
 
+    describe "empty message" do
+      let(:doc) { "" }
+
+      let(:config) do
+        { "skip_empty_rows" => true }
+      end
+
+      it "skips empty rows" do
+        plugin.filter(event)
+        expect(event).to be_cancelled  
+      end
+    end
+
     describe "custom separator" do
       let(:doc) { "big,bird;sesame street" }
 

--- a/spec/filters/csv_spec.rb
+++ b/spec/filters/csv_spec.rb
@@ -59,7 +59,8 @@ describe LogStash::Filters::CSV do
 
       it "skips empty rows" do
         plugin.filter(event)
-        expect(event).to be_cancelled  
+        expect(event.get("tags")).to include("_csvskippedemptyfield") 
+        expect(event).not_to be_cancelled 
       end
     end
 


### PR DESCRIPTION
Added feature to skip empty rows preventing broken event warnings mentioned in the following issue ["Empty Input Lines Produce Hard to Interpret Warning and Broken Event #55"](https://github.com/logstash-plugins/logstash-filter-csv/issues/55)